### PR TITLE
Docs: MVCC와 persistence 설명을 실제 구현에 정합화

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Client
 → Route / DB Adapter
 → DB Query Pool
 → SQL Engine
-→ CSV Table · B+ Tree · WAL
+→ CSV persisted tables · PK/UK B+ Tree · committed table-version chain
 ```
 
 API 요청을 받는 풀과 병렬 SQL을 실행하는 풀을 분리했습니다. 무거운 쿼리가 API worker를 모두 점유하거나 같은 풀을 다시 기다리는 상황을 피하기 위한 선택입니다.
@@ -23,10 +23,10 @@ API 요청을 받는 풀과 병렬 SQL을 실행하는 풀을 분리했습니다
 | 영역 | 구현 내용 |
 | --- | --- |
 | API | POSIX socket 기반 HTTP server와 JSON 응답 |
-| 동시성 | 고정 크기 API pool, DB query pool, row-level write lock |
-| 읽기 | table-snapshot copy-on-write MVCC |
-| 트랜잭션 | private working copy, rollback, commit conflict detection |
-| 저장 | CSV table, PK·UK B+ Tree, WAL recovery |
+| 동시성 | 고정 크기 API pool, DB query pool, table-snapshot COW MVCC, autocommit write mutex shard |
+| 읽기 | immutable committed table version을 선택하는 snapshot read |
+| 트랜잭션 | private working copy, rollback discard, table-head/base conflict detection |
+| 저장 | CSV 임시 파일 작성 후 rename, PK·UK B+ Tree; full WAL recovery는 미구현 |
 | 관찰 | health, metrics, 병렬 조회 trace |
 
 ## 트랜잭션 기준
@@ -36,8 +36,8 @@ API 요청을 받는 풀과 병렬 SQL을 실행하는 풀을 분리했습니다
 ```text
 snapshot 획득
 → private working copy에서 SQL 실행
-→ commit 직전 version conflict 검사
-→ 성공: WAL 기록 후 반영
+→ commit 직전 table head/base conflict 검사
+→ 성공: 새 committed table version 설치 후 CSV flush
 → 실패: working copy 폐기
 ```
 
@@ -45,7 +45,9 @@ snapshot 획득
 
 이 구현은 row-version chain을 두는 일반적인 MVCC가 아니라 table-snapshot COW 방식입니다. 따라서 충돌도 table 단위로 발생할 수 있습니다.
 
-`mv_gc`는 종료된 snapshot을 active snapshot 목록에서 제거합니다. 오래된 row version을 회수하는 함수가 아니며 현재 구현에는 row-version reclamation이 없습니다. `gc_wait`도 남아 있는 active snapshot과 현재 version의 차이를 나타내는 상태값입니다.
+`mv_gc`는 종료된 snapshot id를 active snapshot 목록에서 제거합니다. 이후 `dbapi.c`의 별도 `gc_tabs` 경로가 더 이상 active snapshot에서 보이지 않는 오래된 **table version chain**을 정리합니다. row별 version object를 두는 구조가 아니므로 row-version reclamation이라고 설명하지 않습니다. `gc_wait`는 남아 있는 active snapshot의 최소 version과 현재 version의 차이를 나타냅니다.
+
+단건 autocommit write는 `table + id`를 해시한 1,024개 mutex shard 중 하나로 직렬화됩니다. 해시 충돌이 가능하고 명시적 다중 문장 transaction은 table head/base conflict detection을 사용하므로, 이 장치를 진정한 row-level lock으로 부르지 않습니다.
 
 ## API
 

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -86,6 +86,14 @@ flowchart TD
 4. 성공 시 새 version install
 5. 실패 시 working copy 폐기
 
+#### Snapshot과 table version 정리
+
+`mv_gc`는 read/transaction 종료 시 해당 snapshot id를 active snapshot 목록에서 제거합니다. `dbapi.c`의 `gc_tabs`는 남아 있는 active snapshot이 참조할 수 있는 범위를 계산해 오래된 `TabVer` chain을 정리합니다. row-version object는 사용하지 않습니다.
+
+#### 쓰기 직렬화 범위
+
+단건 autocommit write는 `table + id` hash로 선택한 1,024개 mutex shard를 사용합니다. 이는 동일 hash bucket의 write를 직렬화하는 구현이며, 명시적 transaction의 충돌 단위는 table head/base입니다. 따라서 API engine의 동시성 정책은 row-level lock이 아니라 table-snapshot COW MVCC와 제한된 autocommit write serialization의 조합입니다.
+
 ### 5. 인덱스
 
 기존 `src/legacy/bptree.c` 를 재사용합니다.
@@ -101,6 +109,8 @@ SELECT는 조건을 보고 인덱스 경로를 먼저 시도하고, 맞지 않�
 - API engine: CSV persisted table + in-memory version chain
 
 API engine commit 시에는 CSV를 새 상태로 flush하고, 기존 `.delta`, `.idx` side file은 제거합니다.
+
+CSV persistence는 `<table>.csv.tmp`를 작성하고 rename으로 기존 CSV를 교체합니다. 이 경로에는 WAL append, fsync ordering, startup replay가 없으므로 crash recovery를 제공하는 full WAL로 설명하지 않습니다.
 
 ## `/page` 병렬 처리
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -32,3 +32,11 @@ v1 목표는 안정적인 API/동시성/트랜잭션 시연입니다. DDL까지 
 ## 6. 기본 데이터 루트를 `data/` 로 둔 이유
 
 데모용 fixture를 저장소 루트 CSV와 섞지 않기 위해서입니다. 테스트는 `DB_ROOT` 로 임시 디렉터리를 따로 사용합니다.
+
+## 7. autocommit mutex shard를 row-level lock으로 부르지 않는 이유
+
+mutex index는 `table + id` hash로 선택되어 서로 다른 row도 같은 shard에 충돌할 수 있습니다. 또한 명시적 transaction은 이 lock이 아니라 table head/base conflict detection에 의존합니다. 문서에서는 구현 범위를 `autocommit write mutex shard`로 제한해 표현합니다.
+
+## 8. API persistence를 full WAL로 부르지 않는 이유
+
+API engine은 commit 결과를 임시 CSV에 쓴 뒤 rename합니다. WAL append/replay와 crash recovery ordering이 없으므로 durability는 CSV flush 수준으로 설명합니다. legacy CLI의 `.delta`와 `.idx`는 API engine의 recovery contract로 확장 해석하지 않습니다.

--- a/docs/PRESENTATION_SCRIPT.md
+++ b/docs/PRESENTATION_SCRIPT.md
@@ -51,23 +51,14 @@
 
 ---
 
-## 4. 동시성 정책: MVCC와 Row-level Lock
-
-### MVCC가 막는 것
-
-- 읽는 도중 다른 트랜잭션 커밋이 있어도 중간 상태가 섞여 보이는 문제
-- 트랜잭션 단위 읽기 일관성 붕괴
-
-### Row-level Write Lock이 막는 것
-
-- 같은 `table + id`를 동시에 갱신할 때 생기는 write-write 충돌
-- 동일 row 동시 쓰기에서의 실패 급증
+## 4. 동시성 정책: table-snapshot COW MVCC와 충돌 제어
 
 정리하면:
-- **MVCC = 읽기 일관성 담당**
-- **Row-level lock = 동일 row 동시 쓰기 충돌 담당**
+- **snapshot read = 한 요청·트랜잭션 안의 읽기 일관성**
+- **table head/base 검사 = 명시적 transaction의 write-write conflict detection**
+- **autocommit mutex shard = 단건 write의 제한된 직렬화**
 
-[여기에 MVCC와 Row-level Lock 역할 분리 그림]
+[여기에 snapshot read, table conflict, autocommit serialization 역할 분리 그림]
 
 ---
 
@@ -79,12 +70,14 @@
 - write는 private working copy에 반영
 - commit 시 충돌 검사 후 install
 
-### 5-2) Row-level Write Lock
+### 5-2) Autocommit Write Mutex Shard
 
-- `/api/v1/sql` 단건 쓰기 경로에서 `table+id` 기준 shard lock
-- 같은 id 쓰기는 직렬화, 다른 id는 병렬 허용
+- `/api/v1/sql` 단건 쓰기에서 `table + id` hash로 mutex shard 선택
+- 같은 shard의 쓰기는 직렬화되지만 hash 충돌이 가능함
+- 명시적 transaction은 table head/base conflict detection 사용
+- 따라서 row-level lock이 아니라 제한된 autocommit serialization로 설명
 
-[여기에 동일 id 직렬화 / 다른 id 병렬 처리 그림]
+[여기에 mutex shard 충돌과 table-level conflict 범위 그림]
 
 ---
 
@@ -112,9 +105,9 @@
 동일 조건(`UPDATE only`, 32 VU, 20초) 기준:
 
 - 재시도/락 적용 전: 실패율이 매우 높게 발생(충돌 상황에서 대량 실패)
-- 재시도 + row-level lock 적용 후: **성공률 100%** 확인
+- 재시도 + autocommit mutex shard 정책을 적용한 당시 문서에는 **성공률 100%**로 기록되어 있음
 
-발표에서는 “왜 성공률이 올라갔는지”를 동시성 정책과 연결해서 설명하면 설득력이 높습니다.
+이 수치는 해당 조건의 역사적 관측값이며 일반적인 성공률 보장이 아닙니다. 원시 k6 결과가 저장소에 함께 보존되어 있지 않으므로 외부 제출 자료에서 인용하려면 같은 프로필을 다시 실행해 결과 artifact와 함께 제시해야 합니다.
 
 [여기에 적용 전/후 성공률 비교 막대 그래프 그림]
 
@@ -153,7 +146,7 @@
 
 1. CLI 엔진을 실제 서비스형 API 구조로 확장했다.
 2. MVCC로 읽기 일관성을 확보했다.
-3. Row-level lock으로 동일 row 동시 쓰기 충돌을 제어했다.
+3. table-level conflict detection과 autocommit mutex shard의 범위를 코드 기준으로 검증했다.
 4. 데모와 부하 테스트에서 결과를 수치로 검증했다.
 
 감사합니다.


### PR DESCRIPTION
## Summary

- Aligns MVCC terminology with the table-snapshot COW implementation.
- Separates `mv_gc` snapshot unregistration from `gc_tabs` table-version-chain pruning.
- Replaces row-lock and WAL recovery claims with the actual hashed autocommit mutex and temp-CSV rename persistence boundaries.
- Marks historical k6 wording as historical where raw result artifacts are not preserved.

## Verification

- `test_pool`, `test_mvcc`, `test_dbapi`, `test_tx` passed.
- HTTP integration reached `api_test: ok`; the wrapper then stopped the test server and `make test` exited 0.
- `git diff --check` passed.

## Scope

Documentation only. No database behavior, test, or persistence code changed.
